### PR TITLE
Avoid blocking Home Assistant startup with speedtest refresh tasks

### DIFF
--- a/custom_components/ha_unifi_speedtest/__init__.py
+++ b/custom_components/ha_unifi_speedtest/__init__.py
@@ -173,7 +173,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                             await asyncio.sleep(t)
                             _LOGGER.debug(f"Post-manual-test refresh after {t}s")
                             await coordinator.async_request_refresh()
-                    hass.async_create_task(_post_manual_refreshes())
+                    if config_entry:
+                        config_entry.async_create_background_task(
+                            hass,
+                            _post_manual_refreshes(),
+                            f"{DOMAIN} service speedtest refreshes",
+                        )
+                    else:
+                        hass.async_create_background_task(
+                            _post_manual_refreshes(),
+                            f"{DOMAIN} service speedtest refreshes",
+                        )
 
                 # Return success response
                 return {

--- a/custom_components/ha_unifi_speedtest/button.py
+++ b/custom_components/ha_unifi_speedtest/button.py
@@ -117,7 +117,11 @@ class StartSpeedTestAllButton(ButtonEntity):
                         await asyncio.sleep(t)
                         _LOGGER.debug(f"Button-triggered refresh after {t}s")
                         await coordinator.async_request_refresh()
-                self.hass.async_create_task(_post_refreshes())
+                self._entry.async_create_background_task(
+                    self.hass,
+                    _post_refreshes(),
+                    f"{DOMAIN} button speedtest refreshes",
+                )
                 
         except Exception as e:
             _LOGGER.error(f"Failed to start speed test: {e}")
@@ -153,7 +157,11 @@ class StartSpeedTestWanButton(ButtonEntity):
                         await asyncio.sleep(t)
                         _LOGGER.debug(f"Button-triggered refresh after {t}s for {self._iface}")
                         await coordinator.async_request_refresh()
-                self.hass.async_create_task(_post_refreshes())
+                self._entry.async_create_background_task(
+                    self.hass,
+                    _post_refreshes(),
+                    f"{DOMAIN} button speedtest refreshes {self._iface}",
+                )
                 
         except Exception as e:
             _LOGGER.error(f"Failed to start speed test for {self._iface}: {e}")

--- a/custom_components/ha_unifi_speedtest/sensor.py
+++ b/custom_components/ha_unifi_speedtest/sensor.py
@@ -173,7 +173,11 @@ async def async_setup_entry(
                     await asyncio.sleep(t)
                     _LOGGER.debug(f"Post-test refresh after {t}s")
                     await coordinator.async_request_refresh()
-            hass.async_create_task(_post_test_refreshes())
+            config_entry.async_create_background_task(
+                hass,
+                _post_test_refreshes(),
+                f"{DOMAIN} post-speedtest refreshes",
+            )
 
         except Exception as e:
             error_str = str(e).lower()
@@ -215,7 +219,11 @@ async def async_setup_entry(
             _LOGGER.info(f"Scheduling initial seed speed test in ~{seed_delay}s")
             await asyncio.sleep(seed_delay)
             await run_scheduled_speedtest()
-        hass.async_create_task(_initial_seed())
+        config_entry.async_create_background_task(
+            hass,
+            _initial_seed(),
+            f"{DOMAIN} initial seed speedtest",
+        )
     else:
         _LOGGER.info(f"Automatic speed test scheduling disabled for {api.controller_type} controller")
         _LOGGER.info(f"Data will be polled every {polling_interval} minutes")


### PR DESCRIPTION
## Description
This fixes a Home Assistant startup delay caused by delayed speedtest refresh coroutines being created with hass.async_create_task during integration setup.

When automatic scheduling is enabled, the integration starts an initial seed speedtest after startup and then schedules post-test coordinator refreshes. Because those delayed tasks were created during bootstrap, Home Assistant tracked them and waited through the post-test sleeps before marking startup complete.

This PR switches the initial seed and delayed refresh work to background tasks owned by the config entry, so they remain tied to the integration lifecycle without blocking startup. I also updated button/service-triggered refresh tasks for consistency.

## Related Issues
No issue filed.

## Types of Changes
- Bug fix (non-breaking change that fixes an issue)

## Testing
- Reproduced locally on Home Assistant 2026.5.4 with HA Unifi Speedtest scheduling enabled.
- Before the change, bootstrap logs showed Home Assistant waiting on custom_components/ha_unifi_speedtest/sensor.py _post_test_refreshes() for several minutes before startup completed.
- After the change, the same instance reached RUNNING in about 21 seconds with the integration enabled and scheduling still enabled.
- Verified no ha_unifi_speedtest errors in Home Assistant system logs.
- Ran python -m py_compile for __init__.py, sensor.py, and utton.py.
- Ran git diff --check.